### PR TITLE
docs: Improve many docs part

### DIFF
--- a/.github/copilot-commit-message-instructions.md
+++ b/.github/copilot-commit-message-instructions.md
@@ -1,3 +1,23 @@
-Follow the conventional commit message format.
+Follow the Conventional Commits format strictly for commit messages. Use the structure below:
+
+```
+<type>[optional scope]: <gitmoji> <description>
+
+[optional body]
+```
+
+Guidelines:
+
+1. **Type and Scope**: Choose an appropriate type (e.g., `feat`, `fix`) and optional scope to describe the affected module or feature.
+
+2. **Gitmoji**: Include a relevant `gitmoji` that best represents the nature of the change.
+
+3. **Description**: Write a concise, informative description in the header; use backticks if referencing code or specific terms.
+
+4. **Body**: For additional details, use a well-structured body section:
+   - Use bullet points (`*`) for clarity.
+   - Clearly describe the motivation, context, or technical details behind the change, if applicable.
+
+Commit messages should be clear, informative, and professional, aiding readability and project tracking.
 
 Limit the first line to 72 characters or less.

--- a/.github/copilot-commit-message-instructions.md
+++ b/.github/copilot-commit-message-instructions.md
@@ -1,0 +1,3 @@
+Follow the conventional commit message format.
+
+Limit the first line to 72 characters or less.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,10 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "github.copilot.chat.commitMessageGeneration.instructions": [
+        {
+            "file": ".github/copilot-commit-message-instructions.md"
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The serial number can only be found with physical access to the box. You need to
 
 On this label, there is a 15-character code that represents the serial number of the box.
 
-![How to find your Diagral Serial](docs/how-to-find-diagral-serial.png)
+![How to find your Diagral Serial](https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/how-to-find-diagral-serial.png)
 
 > [!IMPORTANT]
 >

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Library documentation is available [here](https://mguyard.github.io/pydiagral/).
 ## How to find Serial on DIAG56AAX
 
 The serial number can only be found with physical access to the box. You need to open it, and you will find a label with a QR Code.
+
 On this label, there is a 15-character code that represents the serial number of the box.
 
 ![How to find your Diagral Serial](docs/how-to-find-diagral-serial.png)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
   <img src="https://raw.githubusercontent.com/mguyard/pydiagral/main/docs/pydiagral-Logo.png" width="400" />
 </p>
 <p align="center">
-    <h1 align="center">PyDiagral</h1>
-</p>
-<p align="center">
     A powerful and easy-to-use Python library for seamless integration with the Diagral alarm system.
 </p>
 <p align="center">


### PR DESCRIPTION
This pull request includes changes to improve commit message guidelines, update VS Code settings, and refine the README file. The most important changes are summarized below:

Commit message guidelines:

* [`.github/copilot-commit-message-instructions.md`](diffhunk://#diff-70f95a9efd88a2ec38593a8ba9a294e25c2a0cd823204d2005fbc224887323b0R1-R23): Added detailed instructions for following the Conventional Commits format, including guidelines for type and scope, gitmoji usage, description, and body structure.

VS Code settings:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L6-R11): Updated settings to include a reference to the new commit message instructions file for GitHub Copilot.

README file updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-L6): Removed redundant center-aligned header and updated image URL for the "How to find your Diagral Serial" section to use the raw GitHub content link. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-L6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R109)