### PR TITLE
fix(api): 🔧 Refactor API key handling and introduce new exceptions

### DIFF
--- a/src/pydiagral/exceptions.py
+++ b/src/pydiagral/exceptions.py
@@ -37,3 +37,11 @@ class ServerError(DiagralAPIError):
 
 class ClientError(DiagralAPIError):
     """Raised when client returns error."""
+
+
+class APIKeyCreationError(DiagralAPIError):
+    """Raised when API key creation fails."""
+
+
+class APIValidationError(DiagralAPIError):
+    """Raised when API validation fails."""


### PR DESCRIPTION
This pull request includes several changes to the `pydiagral` API to introduce new exceptions and improve error handling. The main changes involve replacing `AuthenticationError` with more specific exceptions and updating the tests accordingly.

### Improvements to error handling:

* [`src/pydiagral/api.py`](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddR19-R20): Added new exceptions `APIKeyCreationError` and `APIValidationError` to handle specific error cases during API key creation and validation. Updated the `set_apikey`, `validate_apikey`, `try_connection`, and `get_system_status` methods to raise these new exceptions instead of `AuthenticationError`. [[1]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddR19-R20) [[2]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL269-R272) [[3]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL288-R300) [[4]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL306-R316) [[5]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddR335) [[6]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL360-R364) [[7]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL418-R429) [[8]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL430-R459) [[9]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL605-R631)

* [`src/pydiagral/exceptions.py`](diffhunk://#diff-c7e684eea9de60ef1f907d96ecedfee7f5d841d072d572d9043c161dcdab130cR40-R47): Introduced new exception classes `APIKeyCreationError` and `APIValidationError` to handle specific error scenarios.

### Updates to tests:

* [`tests/test_pydiagral_api.py`](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L11-R16): Updated test cases to reflect the new exceptions. Replaced `AuthenticationError` with `APIKeyCreationError`, `APIValidationError`, and `ConfigurationError` where appropriate. [[1]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L11-R16) [[2]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L189-R194) [[3]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L201-R221) [[4]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L229-R234) [[5]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L313-R325) [[6]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L339-R344) [[7]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L802-R810) [[8]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L818-R823) [[9]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L843-R851) [[10]](diffhunk://#diff-91d670359c16aa7d072c9c7f94d780290bfb6cdb409cb9f6818c2be821703885L860-R865)