### PR TITLE
fix(api): 🔧 Clean up API keys on connection failure

### DIFF
--- a/src/pydiagral/api.py
+++ b/src/pydiagral/api.py
@@ -447,7 +447,8 @@ class DiagralAPI:
         try:
             await self.get_system_status()
         except DiagralAPIError:
-            if ephemeral and not api_keys_provided:
+            # If connection fails, clean up keys
+            if not api_keys_provided:
                 await self.delete_apikey(apikey=self.__apikey)
             raise
 


### PR DESCRIPTION
This pull request includes a small change to the `src/pydiagral/api.py` file. The change modifies the `try_connection` method to ensure that API keys are cleaned up if the connection fails, regardless of whether the `ephemeral` parameter is set to `True`.

* [`src/pydiagral/api.py`](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL450-R451): Modified the `try_connection` method to clean up API keys if the connection fails, by removing the check for `ephemeral`.