### PR TITLE
feat: Stable version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.6](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.5...v1.5.0-beta.6) (2025-03-01)
+
+
+### Bug Fixes
+
+* **api:** 🔧 Clean up API keys on connection failure ([c8f87c6](https://github.com/mguyard/pydiagral/commit/c8f87c6b4e0091775bf948d6471bc8966c9d25ad))
+
 # [1.5.0-beta.5](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.4...v1.5.0-beta.5) (2025-03-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.3](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.2...v1.5.0-beta.3) (2025-02-28)
+
+
+### Features
+
+* **api:** 🚀 Add `get_alarm_name` method and log alarm name in tests ([96e727f](https://github.com/mguyard/pydiagral/commit/96e727fe851a1086d8689c6fb7204efdb702938d))
+
 # [1.5.0-beta.2](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.1...v1.5.0-beta.2) (2025-02-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.4](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.3...v1.5.0-beta.4) (2025-02-28)
+
+
+### Bug Fixes
+
+* **api:** 🔧 Update log message for alarm name retrieval ([fca40e4](https://github.com/mguyard/pydiagral/commit/fca40e44bccd59f6399ae2b89a29c2b4fcc80172))
+
 # [1.5.0-beta.3](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.2...v1.5.0-beta.3) (2025-02-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.1](https://github.com/mguyard/pydiagral/compare/v1.4.0...v1.5.0-beta.1) (2025-02-28)
+
+
+### Features
+
+* **api:** 🚀 Add testing connection feature ([53981f6](https://github.com/mguyard/pydiagral/commit/53981f6bdb8b797b7f4408fbaf2264b66a58ab38))
+
 # 1.4.0 (2025-02-23)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.2](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.1...v1.5.0-beta.2) (2025-02-28)
+
+
+### Features
+
+* **api:** 🚀 Add connection testing functionality with result handling ([a07bbfc](https://github.com/mguyard/pydiagral/commit/a07bbfc22a1f41418dad0347394cadcab31685e8))
+
 # [1.5.0-beta.1](https://github.com/mguyard/pydiagral/compare/v1.4.0...v1.5.0-beta.1) (2025-02-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.5.0-beta.5](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.4...v1.5.0-beta.5) (2025-03-01)
+
+
+### Bug Fixes
+
+* **api:** 🔧 Refactor API key handling and introduce new exceptions ([b1f6d06](https://github.com/mguyard/pydiagral/commit/b1f6d060e52c0c660e760c1dc86c5fa75613e4b2))
+
 # [1.5.0-beta.4](https://github.com/mguyard/pydiagral/compare/v1.5.0-beta.3...v1.5.0-beta.4) (2025-02-28)
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Welcome to the documentation for pydiagral, a Python library for interacting wit
 
 > [!CAUTION]
 >
-> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to the Home Assistant home automation platform for security reasons.
+> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to any automation platform for security reasons.
 > In no event shall the developer of [`pydiagral`](https://github.com/mguyard/pydiagral) library be held liable for any issues arising from the use of this [`pydiagral`](https://github.com/mguyard/pydiagral) library.
 > The user installs and uses this integration at their own risk and with full knowledge of the potential implications.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Welcome to the documentation for pydiagral, a Python library for interacting wit
 
 `pydiagral` is an asynchronous Python interface for the Diagral alarm system. This library allows users to control and monitor their Diagral alarm system through the official API.
 
+> [!CAUTION]
+>
+> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to the Home Assistant home automation platform for security reasons.
+> In no event shall the developer of [`pydiagral`](https://github.com/mguyard/pydiagral) library be held liable for any issues arising from the use of this [`pydiagral`](https://github.com/mguyard/pydiagral) library.
+> The user installs and uses this integration at their own risk and with full knowledge of the potential implications.
+
 ## ✅ Requirement
 
 To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. You can find more information about the Diagral box [here](https://www.diagral.fr/commande/box-alerte-et-pilotage).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,12 @@ Welcome to the documentation for pydiagral, a Python library for interacting wit
 
 pydiagral is an asynchronous Python interface for the Diagral alarm system. This library allows users to control and monitor their Diagral alarm system through the official API.
 
+> [!CAUTION]
+>
+> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to the Home Assistant home automation platform for security reasons.
+> In no event shall the developer of [`pydiagral`](https://github.com/mguyard/pydiagral) library be held liable for any issues arising from the use of this [`pydiagral`](https://github.com/mguyard/pydiagral) library.
+> The user installs and uses this integration at their own risk and with full knowledge of the potential implications.
+
 ## Requirement
 
 To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. You can find more information about the Diagral box [here](https://www.diagral.fr/commande/box-alerte-et-pilotage).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ pydiagral is an asynchronous Python interface for the Diagral alarm system. This
 
 > [!CAUTION]
 >
-> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to the Home Assistant home automation platform for security reasons.
+> Please note that the Diagral alarm system is a security system, and it may be preferable not to connect it to any automation platform for security reasons.
 > In no event shall the developer of [`pydiagral`](https://github.com/mguyard/pydiagral) library be held liable for any issues arising from the use of this [`pydiagral`](https://github.com/mguyard/pydiagral) library.
 > The user installs and uses this integration at their own risk and with full knowledge of the potential implications.
 

--- a/example_code.py
+++ b/example_code.py
@@ -4,6 +4,13 @@ import os
 
 from dotenv import load_dotenv
 
+from pydiagral.models import (
+    Anomalies,
+    ApiKeyWithSecret,
+    SystemDetails,
+    SystemStatus,
+    Webhook,
+)
 from src.pydiagral import DiagralAPI, DiagralAPIError
 
 # Load environment variables
@@ -15,7 +22,7 @@ logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 # Connection information (replace with your own data)
 # For this, create a .env file in the root of the project with the following content:
@@ -27,17 +34,19 @@ logger = logging.getLogger(__name__)
 #   PIN_CODE=your_pin_code
 #   WEBHOOK_URL=your_webhook_url
 #   LOG_LEVEL=INFO
-USERNAME = os.getenv("USERNAME")
-PASSWORD = os.getenv("PASSWORD")
-SERIAL_ID = os.getenv("SERIAL_ID")
-API_KEY = os.getenv("API_KEY")  # Optional
-SECRET_KEY = os.getenv("SECRET_KEY")  # Optional
+USERNAME: str | None = os.getenv("USERNAME")
+PASSWORD: str | None = os.getenv("PASSWORD")
+SERIAL_ID: str | None = os.getenv("SERIAL_ID")
+API_KEY: str | None = os.getenv("API_KEY")  # Optional
+SECRET_KEY: str | None = os.getenv("SECRET_KEY")  # Optional
 PIN_CODE = int(os.getenv("PIN_CODE"))  # Optional
-WEBHOOK_URL = os.getenv("WEBHOOK_URL")  # Optional
+WEBHOOK_URL: str | None = os.getenv("WEBHOOK_URL")  # Optional
 
 ######################################## CUSTOMIZE THE TESTS ########################################
 #   What do you want to test ?
 #   Switch to True the actions you want to test
+TRY_CONNECTION_WITH_KEYS = False
+TRY_CONNECTION_WITHOUT_KEYS = False
 APIKEY_CREATION = True
 APIKEY_DELETION = True
 LIST_GROUPS = True
@@ -53,12 +62,12 @@ TEST_PARTIAL_ACTIONS = False
 
 ######################################## DON'T MODIFY BELOW THIS LINE ########################################
 
-if APIKEY_CREATION:
+if APIKEY_CREATION or TRY_CONNECTION_WITHOUT_KEYS:
     API_KEY = None
     SECRET_KEY = None
 
 
-async def test_diagral_api():  # noqa: D103
+async def test_diagral_api() -> None:  # noqa: D103
     try:
         # Initialization of the DiagralAPI object
         diagral = DiagralAPI(
@@ -77,7 +86,9 @@ async def test_diagral_api():  # noqa: D103
             if APIKEY_CREATION and (not API_KEY or not SECRET_KEY):
                 await alarm.login()  # Login to the API
                 # await asyncio.sleep(3700) # Wait for the access token to expire
-                api_keys = await alarm.set_apikey()  # Create a new API key
+                api_keys: ApiKeyWithSecret = (
+                    await alarm.set_apikey()
+                )  # Create a new API key
                 logger.info("API Key: %s", api_keys.api_key)  # Display the API key
                 logger.info(
                     "Secret Key: %s", api_keys.secret_key
@@ -85,10 +96,24 @@ async def test_diagral_api():  # noqa: D103
                 await (
                     alarm.validate_apikey()
                 )  # Validate the API key - Optional as already done in set_apikey
-                if APIKEY_DELETION:
-                    await alarm.delete_apikey()  # Delete the API key
 
-            await alarm.get_configuration()  # Get the configuration
+            if TRY_CONNECTION_WITHOUT_KEYS:
+                result: bool = await alarm.try_connection(
+                    ephemeral=True
+                )  # Try to connect to the API without keys
+                if result:
+                    logger.info("Connection (without provided keys) successful")
+                else:
+                    logger.error("Connection (without provided keys) failed")
+
+            if TRY_CONNECTION_WITH_KEYS:
+                result = await alarm.try_connection(
+                    ephemeral=False
+                )  # Try to connect to the API with keys
+                if result:
+                    logger.info("Connection (with provided keys) successful")
+                else:
+                    logger.error("Connection (with provided keys) failed")
 
             if LIST_GROUPS:
                 await alarm.get_devices_info()
@@ -100,16 +125,20 @@ async def test_diagral_api():  # noqa: D103
                     )
 
             if LIST_SYSTEM_DETAILS:
-                system_details = (
+                system_details: SystemDetails = (
                     await alarm.get_system_details()
                 )  # Get the system details
                 logger.info("System Details: %s", system_details)
 
             if LIST_SYSTEM_STATUS:
-                system_status = await alarm.get_system_status()  # Get the system status
+                system_status: SystemStatus = (
+                    await alarm.get_system_status()
+                )  # Get the system status
                 logger.info("System Status: %s", system_status)
 
             if LIST_SYSTEM_CONFIGURATION:
+                if not alarm.alarm_configuration:
+                    await alarm.get_configuration()  # Get the configuration
                 logger.info(
                     "System Configuration: %s",
                     alarm.alarm_configuration.grp_marche_partielle2,
@@ -117,14 +146,14 @@ async def test_diagral_api():  # noqa: D103
 
             if WEHBOOK_REGISTRATION and WEBHOOK_URL:
                 logger.info("-----> WEBHOOK <-----")
-                webhook_register_output = await alarm.register_webhook(
+                webhook_register_output: Webhook | None = await alarm.register_webhook(
                     webhook_url=WEBHOOK_URL,
                     subscribe_to_anomaly=True,
                     subscribe_to_alert=True,
                     subscribe_to_state=True,
                 )
                 logger.info("Webhook Register Output: %s", webhook_register_output)
-                webhook_update_output = await alarm.update_webhook(
+                webhook_update_output: Webhook | None = await alarm.update_webhook(
                     webhook_url=WEBHOOK_URL,
                     subscribe_to_anomaly=True,
                     subscribe_to_alert=True,
@@ -133,38 +162,51 @@ async def test_diagral_api():  # noqa: D103
                 logger.info("Webhook Update Output: %s", webhook_update_output)
                 if WEBHOOK_DELETION:
                     await alarm.delete_webhook()
-                    webhook_sub = await alarm.get_webhook()
+                    webhook_sub: Webhook = await alarm.get_webhook()
 
                 logger.info("Webhook Subscription: %s", webhook_sub)
 
             if GET_ANOMALIES:
                 logger.info("-----> ANOMALIES <-----")
-                anomalies = await alarm.get_anomalies()
+                anomalies: Anomalies | dict = await alarm.get_anomalies()
                 logger.info("Anomalies: %s", anomalies)
 
             if TEST_FULL_ACTIONS:
-                start_result = await alarm.start_system()  # Start the system
+                start_result: SystemStatus = (
+                    await alarm.start_system()
+                )  # Start the system
                 logger.info("Start System with result: %s", start_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
-                stop_result = await alarm.stop_system()  # Stop the system
+                stop_result: SystemStatus = await alarm.stop_system()  # Stop the system
                 logger.info("Stop System with result: %s", stop_result)
 
             if TEST_PRESENCE:
-                presence_result = await alarm.presence()  # Activate the presence mode
+                presence_result: SystemStatus = (
+                    await alarm.presence()
+                )  # Activate the presence mode
                 logger.info("Presence with result: %s", presence_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 stop_result = await alarm.stop_system()  # Stop the system
                 logger.info("Stop System with result: %s", stop_result)
 
             if TEST_PARTIAL_ACTIONS:
-                activategroup_result = await alarm.activate_group(groups=[1, 2])
+                activategroup_result: SystemStatus = await alarm.activate_group(
+                    groups=[1, 2]
+                )
                 logger.info("Activate Group with result: %s", activategroup_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
-                disablegroup_result = await alarm.disable_group(groups=[2])
+                disablegroup_result: SystemStatus = await alarm.disable_group(
+                    groups=[2]
+                )
                 logger.info("Disable Group with result: %s", disablegroup_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 stop_result = await alarm.stop_system()
                 logger.info("Stop System with result: %s", stop_result)
+
+            if (
+                APIKEY_DELETION and APIKEY_CREATION
+            ):  # Only when the API key has been created
+                await alarm.delete_apikey()  # Delete the API key
 
     except DiagralAPIError as e:
         logger.error("Erreur : %s", e)

--- a/example_code.py
+++ b/example_code.py
@@ -240,7 +240,7 @@ async def test_diagral_api() -> None:  # noqa: D103,C901
                 _LOGGER.info("Stop System with result: %s", stop_result)
 
             alarm_name: str = await alarm.get_alarm_name()  # Get the alarm name
-            _LOGGER.info("Alarm Name: %s", alarm_name)
+            _LOGGER.info("Alarm Name is: %s", alarm_name)
 
             if (
                 APIKEY_DELETION and APIKEY_CREATION

--- a/example_code.py
+++ b/example_code.py
@@ -74,7 +74,7 @@ if (
     SECRET_KEY = None
 
 
-async def test_diagral_api() -> None:  # noqa: D103
+async def test_diagral_api() -> None:  # noqa: D103,C901
     try:
         # Initialization of the DiagralAPI object
         diagral = DiagralAPI(

--- a/example_code.py
+++ b/example_code.py
@@ -9,6 +9,7 @@ from pydiagral.models import (
     ApiKeyWithSecret,
     SystemDetails,
     SystemStatus,
+    TryConnectResult,
     Webhook,
 )
 from src.pydiagral import DiagralAPI, DiagralAPIError
@@ -22,7 +23,7 @@ logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
-logger: logging.Logger = logging.getLogger(__name__)
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # Connection information (replace with your own data)
 # For this, create a .env file in the root of the project with the following content:
@@ -47,9 +48,11 @@ WEBHOOK_URL: str | None = os.getenv("WEBHOOK_URL")  # Optional
 #   Switch to True the actions you want to test
 TRY_CONNECTION_WITH_KEYS = False
 TRY_CONNECTION_WITHOUT_KEYS = False
-APIKEY_CREATION = True
-APIKEY_DELETION = True
-LIST_GROUPS = True
+TRY_CONNECTION_WITH_KEYS_EPHEMERAL = False
+TRY_CONNECTION_WITHOUT_KEYS_EPHEMERAL = False
+APIKEY_CREATION = False
+APIKEY_DELETION = False
+LIST_GROUPS = False
 LIST_SYSTEM_DETAILS = False
 LIST_SYSTEM_STATUS = False
 LIST_SYSTEM_CONFIGURATION = False
@@ -62,7 +65,11 @@ TEST_PARTIAL_ACTIONS = False
 
 ######################################## DON'T MODIFY BELOW THIS LINE ########################################
 
-if APIKEY_CREATION or TRY_CONNECTION_WITHOUT_KEYS:
+if (
+    APIKEY_CREATION
+    or TRY_CONNECTION_WITHOUT_KEYS
+    or TRY_CONNECTION_WITHOUT_KEYS_EPHEMERAL
+):
     API_KEY = None
     SECRET_KEY = None
 
@@ -78,47 +85,76 @@ async def test_diagral_api() -> None:  # noqa: D103
             secret_key=SECRET_KEY,
             pincode=PIN_CODE,
         )
-        logger.info("Initialisation de DiagralAPI réussie")
+        _LOGGER.info("Initialisation de DiagralAPI réussie")
 
         # Connection to the Diagral API
         async with diagral as alarm:
-            logger.info("Connection to the Diagral API successful")
+            _LOGGER.info("Connection to the Diagral API successful")
             if APIKEY_CREATION and (not API_KEY or not SECRET_KEY):
                 await alarm.login()  # Login to the API
                 # await asyncio.sleep(3700) # Wait for the access token to expire
                 api_keys: ApiKeyWithSecret = (
                     await alarm.set_apikey()
                 )  # Create a new API key
-                logger.info("API Key: %s", api_keys.api_key)  # Display the API key
-                logger.info(
+                _LOGGER.info("API Key: %s", api_keys.api_key)  # Display the API key
+                _LOGGER.info(
                     "Secret Key: %s", api_keys.secret_key
                 )  # Display the secret key
                 await (
                     alarm.validate_apikey()
                 )  # Validate the API key - Optional as already done in set_apikey
 
-            if TRY_CONNECTION_WITHOUT_KEYS:
-                result: bool = await alarm.try_connection(
-                    ephemeral=True
-                )  # Try to connect to the API without keys
-                if result:
-                    logger.info("Connection (without provided keys) successful")
-                else:
-                    logger.error("Connection (without provided keys) failed")
-
             if TRY_CONNECTION_WITH_KEYS:
-                result = await alarm.try_connection(
+                connection: TryConnectResult = await alarm.try_connection(
                     ephemeral=False
                 )  # Try to connect to the API with keys
-                if result:
-                    logger.info("Connection (with provided keys) successful")
+                if connection.result:
+                    _LOGGER.info("Connection (with provided keys) successful")
                 else:
-                    logger.error("Connection (with provided keys) failed")
+                    _LOGGER.error("Connection (with provided keys) failed")
+
+            if TRY_CONNECTION_WITHOUT_KEYS:
+                connection: TryConnectResult = await alarm.try_connection(
+                    ephemeral=False
+                )  # Try to connect to the API with keys
+                if connection.result:
+                    _LOGGER.info("Connection (with provided keys) successful")
+                    _LOGGER.info("Generated keys are : %s", connection.keys)
+                    _LOGGER.info("Running cleanup by deleting the generated keys")
+                    await alarm.delete_apikey(connection.keys.api_key)  # For cleanup
+                else:
+                    _LOGGER.error("Connection (with provided keys) failed")
+
+            if TRY_CONNECTION_WITH_KEYS_EPHEMERAL:
+                connection: TryConnectResult = await alarm.try_connection(
+                    ephemeral=True
+                )  # Try to connect to the API without keys
+                if connection.result:
+                    if connection.keys is not None:
+                        _LOGGER.warning(
+                            "Keys was returned. Not a normal behavior as keys was provided"
+                        )
+                    _LOGGER.info("Connection (without provided keys) successful")
+                else:
+                    _LOGGER.error("Connection (without provided keys) failed")
+
+            if TRY_CONNECTION_WITHOUT_KEYS_EPHEMERAL:
+                connection: TryConnectResult = await alarm.try_connection(
+                    ephemeral=True
+                )  # Try to connect to the API without keys
+                if connection.result:
+                    if connection.keys is not None:
+                        _LOGGER.warning(
+                            "Keys was returned. Not a normal behavior as keys was provided"
+                        )
+                    _LOGGER.info("Connection (without provided keys) successful")
+                else:
+                    _LOGGER.error("Connection (without provided keys) failed")
 
             if LIST_GROUPS:
                 await alarm.get_devices_info()
                 for group in alarm.alarm_configuration.groups:
-                    logger.info(
+                    _LOGGER.info(
                         "Group %i: %s",
                         group.index,
                         group.name,
@@ -128,80 +164,80 @@ async def test_diagral_api() -> None:  # noqa: D103
                 system_details: SystemDetails = (
                     await alarm.get_system_details()
                 )  # Get the system details
-                logger.info("System Details: %s", system_details)
+                _LOGGER.info("System Details: %s", system_details)
 
             if LIST_SYSTEM_STATUS:
                 system_status: SystemStatus = (
                     await alarm.get_system_status()
                 )  # Get the system status
-                logger.info("System Status: %s", system_status)
+                _LOGGER.info("System Status: %s", system_status)
 
             if LIST_SYSTEM_CONFIGURATION:
                 if not alarm.alarm_configuration:
                     await alarm.get_configuration()  # Get the configuration
-                logger.info(
+                _LOGGER.info(
                     "System Configuration: %s",
                     alarm.alarm_configuration.grp_marche_partielle2,
                 )
 
             if WEHBOOK_REGISTRATION and WEBHOOK_URL:
-                logger.info("-----> WEBHOOK <-----")
+                _LOGGER.info("-----> WEBHOOK <-----")
                 webhook_register_output: Webhook | None = await alarm.register_webhook(
                     webhook_url=WEBHOOK_URL,
                     subscribe_to_anomaly=True,
                     subscribe_to_alert=True,
                     subscribe_to_state=True,
                 )
-                logger.info("Webhook Register Output: %s", webhook_register_output)
+                _LOGGER.info("Webhook Register Output: %s", webhook_register_output)
                 webhook_update_output: Webhook | None = await alarm.update_webhook(
                     webhook_url=WEBHOOK_URL,
                     subscribe_to_anomaly=True,
                     subscribe_to_alert=True,
                     subscribe_to_state=True,
                 )
-                logger.info("Webhook Update Output: %s", webhook_update_output)
+                _LOGGER.info("Webhook Update Output: %s", webhook_update_output)
                 if WEBHOOK_DELETION:
                     await alarm.delete_webhook()
                     webhook_sub: Webhook = await alarm.get_webhook()
 
-                logger.info("Webhook Subscription: %s", webhook_sub)
+                _LOGGER.info("Webhook Subscription: %s", webhook_sub)
 
             if GET_ANOMALIES:
-                logger.info("-----> ANOMALIES <-----")
+                _LOGGER.info("-----> ANOMALIES <-----")
                 anomalies: Anomalies | dict = await alarm.get_anomalies()
-                logger.info("Anomalies: %s", anomalies)
+                _LOGGER.info("Anomalies: %s", anomalies)
 
             if TEST_FULL_ACTIONS:
                 start_result: SystemStatus = (
                     await alarm.start_system()
                 )  # Start the system
-                logger.info("Start System with result: %s", start_result)
+                _LOGGER.info("Start System with result: %s", start_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 stop_result: SystemStatus = await alarm.stop_system()  # Stop the system
-                logger.info("Stop System with result: %s", stop_result)
+                _LOGGER.info("Stop System with result: %s", stop_result)
 
             if TEST_PRESENCE:
                 presence_result: SystemStatus = (
                     await alarm.presence()
                 )  # Activate the presence mode
-                logger.info("Presence with result: %s", presence_result)
+                _LOGGER.info("Presence with result: %s", presence_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 stop_result = await alarm.stop_system()  # Stop the system
-                logger.info("Stop System with result: %s", stop_result)
+                _LOGGER.info("Stop System with result: %s", stop_result)
 
             if TEST_PARTIAL_ACTIONS:
                 activategroup_result: SystemStatus = await alarm.activate_group(
                     groups=[1, 2]
                 )
-                logger.info("Activate Group with result: %s", activategroup_result)
+                _LOGGER.info("Activate Group with result: %s", activategroup_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 disablegroup_result: SystemStatus = await alarm.disable_group(
                     groups=[2]
                 )
-                logger.info("Disable Group with result: %s", disablegroup_result)
+                _LOGGER.info("Disable Group with result: %s", disablegroup_result)
                 await asyncio.sleep(30)  # Wait for 30 seconds
                 stop_result = await alarm.stop_system()
-                logger.info("Stop System with result: %s", stop_result)
+                _LOGGER.info("Stop System with result: %s", stop_result)
 
             if (
                 APIKEY_DELETION and APIKEY_CREATION
@@ -209,7 +245,7 @@ async def test_diagral_api() -> None:  # noqa: D103
                 await alarm.delete_apikey()  # Delete the API key
 
     except DiagralAPIError as e:
-        logger.error("Erreur : %s", e)
+        _LOGGER.error("Erreur : %s", e)
 
 
 if __name__ == "__main__":

--- a/example_code.py
+++ b/example_code.py
@@ -239,6 +239,9 @@ async def test_diagral_api() -> None:  # noqa: D103,C901
                 stop_result = await alarm.stop_system()
                 _LOGGER.info("Stop System with result: %s", stop_result)
 
+            alarm_name: str = await alarm.get_alarm_name()  # Get the alarm name
+            _LOGGER.info("Alarm Name: %s", alarm_name)
+
             if (
                 APIKEY_DELETION and APIKEY_CREATION
             ):  # Only when the API key has been created

--- a/src/pydiagral/api.py
+++ b/src/pydiagral/api.py
@@ -40,7 +40,7 @@ from .models import (
 )
 from .utils import generate_hmac_signature
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
 # Minimum Python version: 3.10
 
@@ -83,17 +83,17 @@ class DiagralAPI:
             or not self.__is_valid_email(username)
         ):
             raise ConfigurationError("username must be a valid non-empty email address")
-        self.username = username
+        self.username: str = username
 
         # Validate password
         if not password or not isinstance(password, str):
             raise ConfigurationError("password must be a non-empty string")
-        self.__password = password
+        self.__password: str = password
 
         # Validate serial_id
         if not serial_id or not isinstance(serial_id, str):
             raise ConfigurationError("serial_id must be a non-empty string")
-        self.serial_id = serial_id
+        self.serial_id: str = serial_id
 
         # Set apikey and secret_key
         self.__apikey = apikey
@@ -103,7 +103,7 @@ class DiagralAPI:
         if pincode is not None:
             if not isinstance(pincode, int):
                 raise ConfigurationError("pincode must be an integer")
-        self.__pincode = pincode
+        self.__pincode: int | None = pincode
 
         # Initialize session and access_token
         self.session: aiohttp.ClientSession | None = None
@@ -118,7 +118,7 @@ class DiagralAPI:
         _LOGGER.info("Successfully initialized DiagralAPI session")
         return self
 
-    async def __aexit__(self, exc_type, exc, tb):
+    async def __aexit__(self, exc_type, exc, tb) -> None:
         """Close the aiohttp ClientSession."""
         if self.session:
             await self.session.close()
@@ -154,8 +154,8 @@ class DiagralAPI:
             _LOGGER.error(error_msg)
             raise SessionError(error_msg)
 
-        url = f"{BASE_URL}/{API_VERSION}/{endpoint}"
-        headers = kwargs.pop("headers", {})
+        url: str = f"{BASE_URL}/{API_VERSION}/{endpoint}"
+        headers: Any = kwargs.pop("headers", {})
         _LOGGER.debug(
             "Sending %s request to %s with headers %s and data %s",
             method,
@@ -168,7 +168,7 @@ class DiagralAPI:
             async with self.session.request(
                 method, url, headers=headers, timeout=timeout, **kwargs
             ) as response:
-                response_data = await response.json()
+                response_data: Any = await response.json()
                 if response.status == 400:
                     response = HTTPErrorResponse(**response_data)
                     raise DiagralAPIError(
@@ -234,13 +234,13 @@ class DiagralAPI:
             raise SessionError(error_msg)
 
         _LOGGER.debug("Attempting to login to Diagral API")
-        _DATA = {"username": self.username, "password": self.__password}
+        _DATA: dict[str, str] = {"username": self.username, "password": self.__password}
         try:
             response_data, *_ = await self._request(
                 "POST", "users/authenticate/login?vendor=DIAGRAL", json=_DATA
             )
             _LOGGER.debug("Login Response data: %s", response_data)
-            login_response = LoginResponse.from_dict(response_data)
+            login_response: LoginResponse = LoginResponse.from_dict(response_data)
             _LOGGER.debug("Login response: %s", login_response)
 
             self.__access_token = login_response.access_token
@@ -251,7 +251,7 @@ class DiagralAPI:
 
             _LOGGER.info("Successfully logged in to Diagral API")
         except DiagralAPIError as e:
-            error_msg = f"Failed to login : {e!s}"
+            error_msg: str = f"Failed to login : {e!s}"
             _LOGGER.error(error_msg)
             raise AuthenticationError(error_msg) from e
 
@@ -272,8 +272,8 @@ class DiagralAPI:
         if not self.__access_token:
             await self.login()
 
-        _DATA = {"serial_id": self.serial_id}
-        _HEADERS = {
+        _DATA: dict[str, str] = {"serial_id": self.serial_id}
+        _HEADERS: dict[str, str] = {
             "Authorization": f"Bearer {self.__access_token}",
         }
 
@@ -281,7 +281,9 @@ class DiagralAPI:
             response_data, *_ = await self._request(
                 "POST", "users/api_key", json=_DATA, headers=_HEADERS
             )
-            set_apikey_response = ApiKeyWithSecret.from_dict(response_data)
+            set_apikey_response: ApiKeyWithSecret = ApiKeyWithSecret.from_dict(
+                response_data
+            )
             self.__apikey = set_apikey_response.api_key
             if not self.__apikey:
                 error_msg = "API key not found in response"
@@ -305,7 +307,7 @@ class DiagralAPI:
                 self.__apikey = None
                 raise
         except DiagralAPIError as e:
-            error_msg = f"Failed to create API key: {e!s}"
+            error_msg: str = f"Failed to create API key: {e!s}"
             _LOGGER.error(error_msg)
             raise AuthenticationError(error_msg) from e
 
@@ -329,7 +331,7 @@ class DiagralAPI:
 
         """
 
-        apikey_to_validate = apikey or self.__apikey
+        apikey_to_validate: str = apikey or self.__apikey
 
         if not apikey_to_validate:
             _LOGGER.warning("No API key provided to validate")
@@ -338,7 +340,7 @@ class DiagralAPI:
         if not self.__access_token:
             await self.login()
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "Authorization": f"Bearer {self.__access_token}",
         }
         response_data, *_ = await self._request(
@@ -346,7 +348,7 @@ class DiagralAPI:
             f"users/systems/{self.serial_id}/api_keys",
             headers=_HEADERS,
         )
-        validate_apikey_response = ApiKeys.from_dict(response_data)
+        validate_apikey_response: ApiKeys = ApiKeys.from_dict(response_data)
         is_valid = any(
             key_info.api_key == apikey_to_validate
             for key_info in validate_apikey_response.api_keys
@@ -375,7 +377,7 @@ class DiagralAPI:
 
         """
 
-        apikey_to_delete = apikey or self.__apikey
+        apikey_to_delete: str = apikey or self.__apikey
 
         if not apikey_to_delete:
             raise AuthenticationError("An API key is required to delete it")
@@ -383,7 +385,7 @@ class DiagralAPI:
         if not self.__access_token:
             await self.login()
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "Authorization": f"Bearer {self.__access_token}",
         }
         await self._request(
@@ -465,14 +467,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
@@ -507,13 +509,13 @@ class DiagralAPI:
         if not self.alarm_configuration:
             raise ConfigurationError("Failed to retrieve alarm configuration")
 
-        device_types = sorted(
+        device_types: list[str] = sorted(
             ["cameras", "commands", "sensors", "sirens", "transmitters"]
         )
         devices_infos = {}
         for device_type in device_types:
             _LOGGER.debug("Retrieving devices information for %s", device_type)
-            devices = getattr(self.alarm_configuration, device_type, None)
+            devices: Any | None = getattr(self.alarm_configuration, device_type, None)
             if devices is not None:
                 devices_infos[device_type] = [
                     {"index": device.index, "label": device.label} for device in devices
@@ -547,14 +549,14 @@ class DiagralAPI:
             raise AuthenticationError("PIN code required to get system details")
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-PIN-CODE": str(self.__pincode),
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
@@ -590,14 +592,14 @@ class DiagralAPI:
             raise AuthenticationError("PIN code required to get system details")
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-PIN-CODE": str(self.__pincode),
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
@@ -644,14 +646,14 @@ class DiagralAPI:
             raise AuthenticationError(f"PIN code required to do system action {action}")
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-PIN-CODE": str(self.__pincode),
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
@@ -768,7 +770,7 @@ class DiagralAPI:
             await self.get_configuration()
 
         # Check if the groups are valid
-        invalid_groups = [
+        invalid_groups: list[int] = [
             group
             for group in groups
             if group not in [g.index for g in self.alarm_configuration.groups]
@@ -779,20 +781,20 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-PIN-CODE": str(self.__pincode),
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
         }
-        data = {"groups": groups}
+        data: dict[str, list[int]] = {"groups": groups}
         response_data, *_ = await self._request(
             "POST",
             f"systems/{self.serial_id}/{action}",
@@ -886,14 +888,14 @@ class DiagralAPI:
             raise AuthenticationError("PIN code required to get system details")
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-PIN-CODE": str(self.__pincode),
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
@@ -967,14 +969,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
@@ -1022,14 +1024,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
@@ -1075,14 +1077,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
@@ -1140,14 +1142,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,
@@ -1248,14 +1250,14 @@ class DiagralAPI:
             )
 
         _TIMESTAMP = str(int(time.time()))
-        _HMAC = generate_hmac_signature(
+        _HMAC: str = generate_hmac_signature(
             timestamp=_TIMESTAMP,
             serial_id=self.serial_id,
             api_key=self.__apikey,
             secret_key=self.__secret_key,
         )
 
-        _HEADERS = {
+        _HEADERS: dict[str, str] = {
             "X-HMAC": _HMAC,
             "X-TIMESTAMP": _TIMESTAMP,
             "X-APIKEY": self.__apikey,

--- a/src/pydiagral/api.py
+++ b/src/pydiagral/api.py
@@ -109,7 +109,6 @@ class DiagralAPI:
         # Initialize session and access_token
         self.session: aiohttp.ClientSession | None = None
         self.__access_token: str | None = None
-        self.access_token_expires: datetime | None = None
 
         # Set default values for other attributes
         self.alarm_configuration: AlarmConfiguration | None = None
@@ -260,9 +259,7 @@ class DiagralAPI:
     async def set_apikey(self) -> ApiKeyWithSecret:
         """Asynchronously set the API key for the Diagral API.
 
-        This method first ensures that the access token is valid and not expired.
-        If the access token is expired, it attempts to log in again to refresh it.
-        Then, it sends a request to create a new API key using the current access token.
+        It sends a request to create a new API key using the current access token.
         If the API key is successfully created, it verifies the API key to ensure its validity.
 
         Returns:
@@ -274,14 +271,6 @@ class DiagralAPI:
         """
 
         if not self.__access_token:
-            await self.login()
-
-        if (
-            self.__access_token
-            and self.access_token_expires
-            and datetime.now() >= self.access_token_expires
-        ):
-            _LOGGER.warning("Access token has expired, attempting to login again")
             await self.login()
 
         _DATA = {"serial_id": self.serial_id}

--- a/src/pydiagral/api.py
+++ b/src/pydiagral/api.py
@@ -400,7 +400,7 @@ class DiagralAPI:
             self.__apikey = None
             self.__secret_key = None
 
-    async def try_connection(self, ephemeral: bool = True) -> bool:
+    async def try_connection(self, ephemeral: bool = True) -> TryConnectResult:
         """Test connection with the Diagral system.
 
         This method tests the connection by either using provided API credentials or generating
@@ -488,6 +488,28 @@ class DiagralAPI:
             "Successfully retrieved configuration: %s", self.alarm_configuration
         )
         return self.alarm_configuration
+
+    async def get_alarm_name(self) -> str:
+        """Get the name of the alarm from the configuration.
+
+        Returns:
+            str: The name of the alarm from the configuration.
+
+        Raises:
+            ConfigurationError: If unable to retrieve the alarm configuration.
+
+        Note:
+            This method will attempt to fetch the configuration if it hasn't been loaded yet.
+
+        """
+
+        if not self.alarm_configuration:
+            await self.get_configuration()
+
+        if not self.alarm_configuration:
+            raise ConfigurationError("Failed to retrieve alarm configuration")
+
+        return self.alarm_configuration.alarm.name
 
     async def get_devices_info(self) -> DeviceList:
         """Asynchronously retrieves information about various device types from the alarm configuration.

--- a/src/pydiagral/api.py
+++ b/src/pydiagral/api.py
@@ -447,7 +447,8 @@ class DiagralAPI:
         try:
             await self.get_system_status()
         except DiagralAPIError:
-            if ephemeral and not api_keys_provided:
+            # If connection fails, clean up keys
+            if not api_keys_provided:
                 await self.delete_apikey(apikey=self.__apikey)
             raise
 

--- a/src/pydiagral/exceptions.py
+++ b/src/pydiagral/exceptions.py
@@ -37,3 +37,11 @@ class ServerError(DiagralAPIError):
 
 class ClientError(DiagralAPIError):
     """Raised when client returns error."""
+
+
+class APIKeyCreationError(DiagralAPIError):
+    """Raised when API key creation fails."""
+
+
+class APIValidationError(DiagralAPIError):
+    """Raised when API validation fails."""

--- a/src/pydiagral/exceptions.py
+++ b/src/pydiagral/exceptions.py
@@ -10,8 +10,8 @@ class DiagralAPIError(Exception):
         :param message: The error message.
         :param status_code: The status code of the error, if any.
         """
-        self.message = message
-        self.status_code = status_code
+        self.message: str = message
+        self.status_code: int | None = status_code
         super().__init__(self.message)
 
 

--- a/src/pydiagral/models.py
+++ b/src/pydiagral/models.py
@@ -355,6 +355,30 @@ class ApiKeys(CamelCaseModel):
         )
 
 
+@dataclass
+class TryConnectResult(CamelCaseModel):
+    """A class representing the result of an API connection attempt.
+
+    This class is used to store the result of an API connection attempt
+    and the associated API keys if the connection was successful.
+
+    Attributes:
+        result (bool | None): Whether the connection attempt was successful. Defaults to False.
+        keys (ApiKeyWithSecret | None): The API keys associated with the successful connection. Defaults to None.
+
+    Example:
+        >>> result = TryConnectResult(result=True, keys=api_key_obj)
+        >>> print(result.result)
+        True
+        >>> print(result.keys)
+        ApiKeyWithSecret(api_key='abc123', api_secret='xyz789')
+
+    """
+
+    result: bool | None = False
+    keys: ApiKeyWithSecret | None = None
+
+
 #####################################
 # Data models for alarm configuration
 #####################################

--- a/src/pydiagral/models.py
+++ b/src/pydiagral/models.py
@@ -15,7 +15,7 @@ import re
 import types
 from typing import TypeVar, Union, get_args, get_origin, get_type_hints
 
-logger = logging.getLogger(__name__)
+logger: logging.Logger = logging.getLogger(__name__)
 
 
 #######################################################

--- a/src/pydiagral/utils.py
+++ b/src/pydiagral/utils.py
@@ -10,5 +10,5 @@ def generate_hmac_signature(
 ) -> str:
     """Generate an HMAC signature for the given parameters."""
     timestamp = str(int(time.time()))
-    message = f"{timestamp}.{serial_id}.{api_key}"
+    message: str = f"{timestamp}.{serial_id}.{api_key}"
     return hmac.new(secret_key.encode(), message.encode(), hashlib.sha256).hexdigest()


### PR DESCRIPTION
This pull request includes several updates and improvements to the `pydiagral` project, focusing on bug fixes, new features, and code quality enhancements. The most important changes involve updating the `CHANGELOG.md` with recent versions, adding caution notes in the documentation, and refactoring the `example_code.py` file for better type safety and logging.

### Documentation Updates:
* `README.md` and `docs/index.md`: Added caution notes warning users about the security implications of connecting the Diagral alarm system to any automation platform. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R41) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R11-R16)

### Changelog Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R42): Documented new versions 1.5.0-beta.1 to 1.5.0-beta.6, including features like connection testing functionality and bug fixes related to API key handling.

### Code Refactoring:
* `example_code.py`: 
  * Imported additional models for better structure.
  * Added type annotations for environment variables and logger.
  * Refactored connection testing and logging to improve readability and maintainability. [[1]](diffhunk://#diff-143259b536d771b4d56b8a970b2380f0b99e8806e370f37b533855a3796dee2cL56-R77) [[2]](diffhunk://#diff-143259b536d771b4d56b8a970b2380f0b99e8806e370f37b533855a3796dee2cL72-R251)

### Internal Code Improvements:
* `src/pydiagral/api.py`: 
  * Added new exceptions and improved type annotations for better error handling and code clarity. [[1]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddR19-R20) [[2]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL87-R99)
  * Enhanced the `_request` and `login` methods with type annotations and improved logging. [[1]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL159-R161) [[2]](diffhunk://#diff-2d2451a06c62f251517e592926253045922a4592e4a6b4ca3bd60a57547ce8ddL239-R246)