### PR TITLE
fix(models): 🐛 Allow username and user_type to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.5.1-beta.1](https://github.com/mguyard/pydiagral/compare/v1.5.0...v1.5.1-beta.1) (2025-03-09)
+
+
+### Bug Fixes
+
+* **models:** 🐛 Allow `username` and `user_type` to be optional ([d0f173c](https://github.com/mguyard/pydiagral/commit/d0f173cae4377cded21a7f4a6bc9ca0d13035df5))
+
 # [1.5.0](https://github.com/mguyard/pydiagral/compare/v1.4.0...v1.5.0) (2025-03-02)
 
 

--- a/src/pydiagral/models.py
+++ b/src/pydiagral/models.py
@@ -1250,8 +1250,8 @@ class WebHookNotificationUser(CamelCaseModel):
     """WebHookNotificationUser represents a user who receives webhook notifications.
 
     Attributes:
-        username (str): The username of the user.
-        user_type (str): The type of the user.
+        username (str | None): The username of the user.
+        user_type (str | None): The type of the user.
 
     Example:
         >>> user = WebHookNotificationUser(username="Dark Vador", user_type="owner")
@@ -1262,8 +1262,8 @@ class WebHookNotificationUser(CamelCaseModel):
 
     """
 
-    username: str
-    user_type: str
+    username: str | None = None
+    user_type: str | None = None
 
 
 @dataclass
@@ -1311,7 +1311,7 @@ class WebHookNotification(CamelCaseModel):
     alarm_description: str
     group_index: str
     detail: WebHookNotificationDetail
-    user: WebHookNotificationUser
+    user: WebHookNotificationUser | None
     date_time: datetime
 
     @classmethod
@@ -1372,6 +1372,17 @@ class WebHookNotification(CamelCaseModel):
                 return "STATUS"
             return "UNKNOWN"
 
+        # Create user object only if user data exists
+        user_data = data.get("user")
+        user: WebHookNotificationUser | None = (
+            WebHookNotificationUser(
+                username=user_data.get("username"),
+                user_type=user_data.get("user_type"),
+            )
+            if user_data
+            else None
+        )
+
         return cls(
             transmitter_id=data.get("transmitter_id"),
             alarm_type=alarm_type(data.get("alarm_code")),
@@ -1383,10 +1394,7 @@ class WebHookNotification(CamelCaseModel):
                 device_index=data.get("detail", {}).get("device_index", None),
                 device_label=data.get("detail", {}).get("device_label", None),
             ),
-            user=WebHookNotificationUser(
-                username=data.get("user", {}).get("username", None),
-                user_type=data.get("user", {}).get("user_type", None),
-            ),
+            user=user,
             date_time=datetime.fromisoformat(data["date_time"].replace("Z", "+00:00")),
         )
 


### PR DESCRIPTION
This pull request includes changes to the `src/pydiagral/models.py` file to make certain attributes optional and updates the `CHANGELOG.md` to reflect these changes. The most important changes are grouped by theme below:

### Model Updates:

* Modified `WebHookNotificationUser` class to make `username` and `user_type` attributes optional by changing their types to `str | None` and setting default values to `None`. [[1]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L1253-R1254) [[2]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L1265-R1266)
* Updated `WebHookNotification` class to make the `user` attribute optional by changing its type to `WebHookNotificationUser | None`.

### Code Refactoring:

* Refactored the `alarm_type` function to create a `WebHookNotificationUser` object only if user data exists, ensuring that the `user` attribute can be `None`. [[1]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30R1375-R1385) [[2]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L1386-R1397)