### PR TITLE
fix(models): ✨ Rename fields in `AlarmConfiguration` following Diagral changes

### DIFF
--- a/src/pydiagral/models.py
+++ b/src/pydiagral/models.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 import logging
 import re
 import types
-from typing import TypeVar, Union, get_args, get_origin, get_type_hints
+from typing import Self, Union, get_args, get_origin, get_type_hints
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -54,9 +54,6 @@ class CamelCaseModel:
 
     """
 
-    # Type variable for the class itself
-    T = TypeVar("T", bound="CamelCaseModel")
-
     def to_dict(self) -> dict:
         """Convert the instance attributes to a dictionary, transforming attribute names.
 
@@ -90,7 +87,7 @@ class CamelCaseModel:
         return result
 
     @classmethod
-    def _from_dict_recursive(cls: type[T], data: dict, target_cls: type[T]) -> T:
+    def _from_dict_recursive(cls, data: dict, target_cls: type[Self]) -> Self:
         """Recursively converts a dictionary to an instance of the specified target class.
 
         This method handles nested dictionaries and lists, converting them to the appropriate
@@ -98,12 +95,12 @@ class CamelCaseModel:
         by handling `Union` types and removing `None` from the type hints.
 
         Args:
-            cls (type[T]): The class that this method is a part of.
+            cls (type[Self]): The class that this method is a part of.
             data (dict): The dictionary to convert.
-            target_cls (type[T]): The target class to convert the dictionary to.
+            target_cls (type[Self]): The target class to convert the dictionary to.
 
         Returns:
-            T: An instance of the target class populated with the data from the dictionary.
+            An instance of the target class populated with the data from the dictionary.
 
         Raises:
             TypeError: If the target class cannot be instantiated with the provided data.
@@ -187,15 +184,15 @@ class CamelCaseModel:
         return target_cls(**init_values)
 
     @classmethod
-    def from_dict(cls: type[T], data: dict) -> T:
+    def from_dict(cls, data: dict) -> Self:
         """Create an instance of the class from a dictionary.
 
         Args:
-            cls (type[T]): The class type to instantiate.
+            cls (type[Self]): The class type to instantiate.
             data (dict): The dictionary containing the data to populate the instance.
 
         Returns:
-            T: An instance of the class populated with the data from the dictionary.
+            An instance of the class populated with the data from the dictionary.
 
         Example:
             >>> data = {"diagral_id": 123, "user_id": 456, "access_token": "abc123"}

--- a/src/pydiagral/models.py
+++ b/src/pydiagral/models.py
@@ -830,11 +830,11 @@ class AlarmConfiguration(CamelCaseModel):
         reading_date (datetime | None): The date when the configuration was read, aliased as "readingDate".
         transceivers (list[TransceiverModel] | None): A list of transceiver models.
         transmitters (list[TransmitterModel] | None): A list of transmitter models.
-        grp_marche_presence (list[int] | None): A list of group marche presence, aliased as "grpMarchePresence".
+        presence_group (list[int] | None): A list of group marche presence, aliased as "presenceGroup".
         installation_state (int | None): The state of the installation, aliased as "installationState".
         central_information (CentralInformation | None): Information about the central unit, aliased as "centralInformation".
-        grp_marche_partielle1 (list[int] | None): A list of group marche partielle 1, aliased as "grpMarchePartielle1".
-        grp_marche_partielle2 (list[int] | None): A list of group marche partielle 2, aliased as "grpMarchePartielle2".
+        partial_group1 (list[int] | None): A list of group marche partielle 1, aliased as "partialGroup1".
+        partial_group2 (list[int] | None): A list of group marche partielle 2, aliased as "partialGroup2".
 
     Example:
         >>> alarm_config = AlarmConfiguration(
@@ -847,11 +847,11 @@ class AlarmConfiguration(CamelCaseModel):
         ...     reading_date=datetime(2023, 10, 1),
         ...     transceivers=[TransceiverModel(uid="11223", type=5)],
         ...     transmitters=[TransmitterModel(uid="44556", type=6)],
-        ...     grp_marche_presence=[1, 2, 3],
+        ...     presence_group=[1, 2, 3],
         ...     installation_state=1,
         ...     central_information=CentralInformation(has_plug=True),
-        ...     grp_marche_partielle1=[4, 5, 6],
-        ...     grp_marche_partielle2=[7, 8, 9]
+        ...     partial_group1=[4, 5, 6],
+        ...     partial_group2=[7, 8, 9]
         ... )
         >>> print(alarm_config.alarm.name)
         Home Alarm
@@ -870,8 +870,8 @@ class AlarmConfiguration(CamelCaseModel):
     )
     transceivers: list[TransceiverModel] | None = None
     transmitters: list[TransmitterModel] | None = None
-    grp_marche_presence: list[int] | None = field(
-        default=None, metadata={"alias": "grpMarchePresence"}
+    presence_group: list[int] | None = field(
+        default=None, metadata={"alias": "presenceGroup"}
     )
     installation_state: int | None = field(
         default=None, metadata={"alias": "installationState"}
@@ -879,11 +879,11 @@ class AlarmConfiguration(CamelCaseModel):
     central_information: CentralInformation | None = field(
         default=None, metadata={"alias": "centralInformation"}
     )
-    grp_marche_partielle1: list[int] | None = field(
-        default=None, metadata={"alias": "grpMarchePartielle1"}
+    partial_group1: list[int] | None = field(
+        default=None, metadata={"alias": "partialGroup1"}
     )
-    grp_marche_partielle2: list[int] | None = field(
-        default=None, metadata={"alias": "grpMarchePartielle2"}
+    partial_group2: list[int] | None = field(
+        default=None, metadata={"alias": "partialGroup2"}
     )
 
 

--- a/tests/data/configuration_sample.json
+++ b/tests/data/configuration_sample.json
@@ -323,7 +323,7 @@
             "canInhibit": false
         }
     ],
-    "grpMarchePresence": [
+    "presenceGroup": [
         1,
         2,
         4
@@ -345,10 +345,10 @@
         "canInhibit": false,
         "parameterGsmSaved": false
     },
-    "grpMarchePartielle1": [
+    "partialGroup1": [
         1
     ],
-    "grpMarchePartielle2": [
+    "partialGroup2": [
         2
     ]
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/pydiagral/models.py` file, focusing on type hint improvements and renaming attributes to follow Diagral changes. Additionally, corresponding updates have been made in the `tests/data/configuration_sample.json` file to reflect these attribute name changes.

Type hint improvements:

* Replaced `TypeVar` with `Self` in type hints to simplify the type annotations in the `CamelCaseModel` class methods. [[1]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L16-R16) [[2]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L93-R103) [[3]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L190-R195)

Attribute renaming for clarity:

* Renamed attributes in the `AlarmConfiguration` class and updated their aliases to be more descriptive. For example, `grp_marche_presence` was renamed to `presence_group`, and `grp_marche_partielle1` and `grp_marche_partielle2` were renamed to `partial_group1` and `partial_group2`, respectively. [[1]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L833-R834) [[2]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L850-R851) [[3]](diffhunk://#diff-c8cbc99cb8ef7b92a7e3e7859e08cf2dffa267ffa2df13c32feb632090af1e30L873-R883)

Corresponding test updates:

* Updated `tests/data/configuration_sample.json` to reflect the new attribute names in the `AlarmConfiguration` class. [[1]](diffhunk://#diff-6b44306ef144db824959adb9a9a3b3109ac3644ae4ed5481b306a1fb9acf3983L326-R326) [[2]](diffhunk://#diff-6b44306ef144db824959adb9a9a3b3109ac3644ae4ed5481b306a1fb9acf3983L348-R351)