### PR TITLE
chore: clarify hardware support and improve doc deployment workflow

### DIFF
--- a/.github/workflows/release_and_doc.yaml
+++ b/.github/workflows/release_and_doc.yaml
@@ -61,7 +61,11 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     needs: release
-    if: needs.release.outputs.new_release_published == 'true'
+    if: |
+      needs.release.outputs.new_release_published == 'true' ||
+      contains(github.event.commits.*.modified, 'docs/') ||
+      contains(github.event.commits.*.added, 'docs/') ||
+      contains(github.event.commits.*.modified, 'mkdocs.yml')
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -73,8 +77,17 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Set the PYPROJECT_VERSION environment variable
-        run: echo "PYPROJECT_VERSION=${{ needs.release.outputs.new_release_version }}" >> $GITHUB_ENV
+      - name: Resolve package version
+        id: version
+        run: |
+          if [ "${{ needs.release.outputs.new_release_published }}" == "true" ]; then
+            echo "PYPROJECT_VERSION=${{ needs.release.outputs.new_release_version }}" >> $GITHUB_ENV
+          else
+            LATEST=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest \
+              | grep '"tag_name"' \
+              | sed 's/.*"tag_name": "v\([^"]*\)".*/\1/')
+            echo "PYPROJECT_VERSION=$LATEST" >> $GITHUB_ENV
+          fi
 
       - name: Install dependencies
         run: |
@@ -83,7 +96,7 @@ jobs:
           pip install -e .
 
       - name: Build documentation
-        run: mkdocs build --strict #--verbose
+        run: mkdocs build --strict
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,5 @@ cython_debug/
 .DS_Store
 
 # Exclusion of diagnostic code files
+.devcontainer/devcontainer-lock.json
 diag_code.py

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Welcome to the documentation for pydiagral, a Python library for interacting wit
 
 ## ✅ Requirement
 
-To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. DIAG56AAX is End of Sales but you can find more information about the DIAG59AAX [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.
+To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API.
+__DIAG56AAX is End of Sales but you can find more information about the [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.__
 
 ## 📦 Key Features
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Welcome to the documentation for pydiagral, a Python library for interacting wit
 
 ## ✅ Requirement
 
-To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. You can find more information about the Diagral box [here](https://www.diagral.fr/commande/box-alerte-et-pilotage).
+To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. DIAG56AAX is End of Sales but you can find more information about the DIAG59AAX [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.
 
 ## 📦 Key Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ pydiagral is an asynchronous Python interface for the Diagral alarm system. This
 
 ## Requirement
 
-To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. DIAG56AAX is End-of-Sales but you can find more information about the DIAG59AAX [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.
+To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. DIAG56AAX is End of Sales but you can find more information about the DIAG59AAX [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.
 
 ## Key Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,8 @@ pydiagral is an asynchronous Python interface for the Diagral alarm system. This
 
 ## Requirement
 
-To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API. DIAG56AAX is End of Sales but you can find more information about the DIAG59AAX [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.
+To use this library, which leverages the Diagral APIs, you must have a Diagral box (DIAG56AAX or DIAG59AAX). This box connects your Diagral alarm system to the internet, enabling interaction with the alarm system via the API.
+__DIAG56AAX is End of Sales but you can find more information about the [DIAG59AAX](https://www.diagral.fr/2026/01/19/nouvelle-centrale-dalarme-ip-4g-diagral-diag99agx/) available inside the DIAG99AGX.__
 
 ## Key Features
 


### PR DESCRIPTION
This pull request updates documentation to clarify hardware requirements and improves the deployment workflow for documentation. The workflow is now more robust, ensuring documentation is built and deployed when relevant files change, not just on new releases. Additionally, it enhances how the package version is determined during deployment.

Documentation updates:

* Updated both `README.md` and `docs/index.md` to clarify that the library supports both DIAG56AAX and DIAG59AAX Diagral boxes, and provided a new link to information about the DIAG59AAX, noting that DIAG56AAX is end-of-sales. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R48) [[2]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L19-R20)

Workflow improvements:

* Modified `.github/workflows/release_and_doc.yaml` so that the documentation deployment job also triggers when files in the `docs/` directory or `mkdocs.yml` are added or modified, not just on new releases.
* Improved version resolution in the workflow: if a new release was not published, the workflow now fetches the latest release tag from GitHub to set the `PYPROJECT_VERSION` environment variable.
* Cleaned up the documentation build command by removing unnecessary commented-out flags in the workflow.